### PR TITLE
add support for scala 2.10 compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,13 @@ scalacOptions in(Compile, doc) := Seq("-no-link-warnings")
 
 scalaVersion := "2.12.11"
 
-crossScalaVersions := Seq("2.12.11", "2.11.12", "2.13.1")
+crossScalaVersions := Seq("2.12.11", "2.11.12", "2.13.1", "2.10.7")
 
 libraryDependencies ++= {
-  Seq(
-    "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+  (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, scalaMajor)) if scalaMajor <= 10 => None
+    case _ => Some("org.scala-lang.modules" %% "scala-xml" % "1.2.0")
+  }).toSeq ++ Seq(
     "org.apache.commons" % "commons-math3" % "3.6.1",
     "org.apache.commons" % "commons-text" % "1.6",
     "io.spray" %% "spray-json" % "1.3.5",

--- a/src/main/scala/org/pmml4s/model/TreeModel.scala
+++ b/src/main/scala/org/pmml4s/model/TreeModel.scala
@@ -391,7 +391,10 @@ class Node(
   val defaultChildNode: Option[Node] = defaultChild.flatMap {
     x =>
       children.find {
-        y => y.id.contains(x)
+        y => y.id match {
+          case Some(id) => id == x
+          case None => false
+        }
       }
   }
 }


### PR DESCRIPTION
I would love to use this library with some models we have in the PMML format, but unfortunately I'm dealing with some old code bases that still use Scala 2.10 in a couple of places.  As a result, in order to use the library I needed to add support to build the PMML4S project for Scala 2.10.

This primarily just affects the `build.sbt` file.  Since the `scala-xml` library was split from the standard library starting in Scala 2.11, I had to add a small branch in the dependencies to support just using the standard library in Scala 2.10.

Unfortunately, one other change was needed to support Scala 2.10.  The `contains` method wasn't added to the `Option` class until 2.11.  There was one usage of this in the library that I had to change to a `match` statement instead.  Everything else compiled in Scala 2.10 without any issues, and the unit tests all still passed when running `sbt test`.

Let me know if you need any other details.