### PR TITLE
fix: Restrict pipeline permissions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [master, main]
     tags: ["*"]
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Hi! This PR restricts permissions on the pipeline. For details, see the best security practice suggestions provided by GitHub https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information.